### PR TITLE
Use time of passed in clock for fetching jobs

### DIFF
--- a/src/proletarian/db.clj
+++ b/src/proletarian/db.clj
@@ -51,7 +51,7 @@
       job-table))))
 
 (defn- now [clock]
-  (.format (.withZone (DateTimeFormatter/ofPattern "yyyy-MM-dd HH:mm:ss")
+  (.format (.withZone (DateTimeFormatter/ofPattern "yyyy-MM-dd HH:mm:ss.SSS")
                       (ZoneId/systemDefault))
            (if clock
              (Instant/now clock)

--- a/src/proletarian/db.clj
+++ b/src/proletarian/db.clj
@@ -5,7 +5,8 @@
   (:import (java.sql Connection Timestamp)
            (java.util UUID)
            (javax.sql DataSource)
-           (java.time Instant)))
+           (java.time Instant ZoneId)
+           (java.time.format DateTimeFormatter)))
 
 (set! *warn-on-reflection* true)
 
@@ -50,8 +51,8 @@
       job-table))))
 
 (defn- now [clock]
-  (.format (.withZone (java.time.format.DateTimeFormatter/ofPattern "yyyy-MM-dd HH:mm:ss")
-                      (java.time.ZoneId/systemDefault))
+  (.format (.withZone (DateTimeFormatter/ofPattern "yyyy-MM-dd HH:mm:ss")
+                      (ZoneId/systemDefault))
            (if clock
              (Instant/now clock)
              (Instant/now))))


### PR DESCRIPTION
hi msolli,

this is a draft for trying to solve the following problem:

i have a setup where i want to test a larger subsystem, of which proletarian is a part. to speed up the tests, i want to pass in a clock which i can control. i expected the `:proletarian/clock` config argument to be for just that. however, i found out while controlling the time worked in the test cases that come with the **proletarian** project, in my test setup it did not work because the `now()` in `db.clj` (here in line 46) does fetch jobs based on the system clock, not on the one specifically provided as argument.



