### PR TITLE
New config option for invoking handler-fn with all job details

### DIFF
--- a/examples/example_c/worker.clj
+++ b/examples/example_c/worker.clj
@@ -1,6 +1,6 @@
 (ns example-c.worker
-  (:require [examples.common :as common]
-            [example-c.enqueue-jobs :as enqueue-jobs]
+  (:require [example-c.enqueue-jobs :as enqueue-jobs]
+            [examples.common :as common]
             [next.jdbc :as jdbc]
             [proletarian.worker :as worker]))
 
@@ -15,7 +15,16 @@
     (println "Starting worker for :proletarian/default queue with polling interval 1 s")
     (let [worker (worker/create-queue-worker ds
                                              enqueue-jobs/handle-job!
-                                             {:proletarian/polling-interval-ms 1000
-                                              :proletarian/on-shutdown (partial on-shutdown ds)
-                                              :proletarian/install-jvm-shutdown-hook? true})]
-      (worker/start! worker))))
+                                             {:proletarian/polling-interval-ms        1000
+                                              :proletarian/on-shutdown                (partial on-shutdown ds)
+                                              :proletarian/install-jvm-shutdown-hook? true
+                                              :proletarian/handler-fn-mode            :advanced})]
+      (worker/start! worker)
+      worker)))
+
+(comment
+  ;; Create and start a worker
+  (def +worker+ (run {}))
+
+  ;; Stop the worker
+  (worker/stop! +worker+))

--- a/src/proletarian/worker.clj
+++ b/src/proletarian/worker.clj
@@ -163,12 +163,12 @@
        - `:default` – Call the `handler-fn` with two arguments, the job type and the payload (see `handler-fn` above)
        - `:advanced` - Call the `handler-fn` with one argument, a map with the job's attributes:
            `:proletarian.job/job-type`, `:proletarian.job/payload`, `:proletarian.job/job-id`, `:proletarian.job/queue`,
-           `:proletarian.job/enqueued-at`, :proletarian.job/process-at` and `:proletarian.job/attempts`.
+           `:proletarian.job/enqueued-at`, `:proletarian.job/process-at` and `:proletarian.job/attempts`.
    * `:proletarian/retry-strategy-fn` – a function that will be called to provide the __retry strategy__ for a job if it
        fails. It should be an arity-2 function or multimethod. The first argument is a map with the job's attributes:
        `:proletarian.job/job-type`, `:proletarian.job/payload`, `:proletarian.job/job-id`, `:proletarian.job/queue`,
-       `:proletarian.job/enqueued-at`, :proletarian.job/process-at` and `:proletarian.job/attempts`. The second argument
-       is the exception that caused the job to fail. It should return a map that specifies the
+       `:proletarian.job/enqueued-at`, `:proletarian.job/process-at` and `:proletarian.job/attempts`. The second
+       argument is the exception that caused the job to fail. It should return a map that specifies the
        [retry strategy](/readme#retries).
    * `:proletarian/failed-job-fn` – a function that will be called when a job has failed after retries. It should be an
        arity-2 function or multimethod. The first argument is a map with the job's attributes (see


### PR DESCRIPTION
Developers want to have internal details about the job available to them, such as job-id, when the handler function is called. Currently the handler function must be an arity-2 function with the job-type and payload as arguments. Internal details such as job-id, number of attempts, timestamps and the queue is not available to the handler functions.

Different approaches to solve this has been dicussed in issue #16. The proposed approach is not among the discussed. It has the advantage of not breaking existing code, and does not increase the complexity of the library much.

With this change, a config option is introduced that enables an _advanced_ mode for the handler function. By setting `:proletarian/handler-fn-mode` to `:advanced` the handler function is called with one argument only, which is a map of information about the job. The keys in this map are:
`:proletarian.job/job-type`
`:proletarian.job/payload`
`:proletarian.job/job-id`
`:proletarian.job/queue`
`:proletarian.job/enqueued-at`
`:proletarian.job/process-at`
`:proletarian.job/attempts`

Example C has been updated to showcase the new functionality.